### PR TITLE
Added initialisation for this["NAMESPACE"]

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,8 @@ module.exports = function tojst (fileName, settings) {
         compiled.push('});');
       }
 
+      compiled.unshift(getNamespace(options.namespace) + ' = ' + getNamespace(options.namespace) + ' || {};');
+
       this.queue(new gulpUtil.File({
         path: fileName,
         contents: new Buffer(compiled.join(options.separator))

--- a/index.js
+++ b/index.js
@@ -106,8 +106,6 @@ module.exports = function tojst (fileName, settings) {
       	compiled.unshift(getNamespace(options.namespace) + ' = ' + getNamespace(options.namespace) + ' || {};');
       }
 
-
-
       this.queue(new gulpUtil.File({
         path: fileName,
         contents: new Buffer(compiled.join(options.separator))

--- a/index.js
+++ b/index.js
@@ -102,9 +102,11 @@ module.exports = function tojst (fileName, settings) {
           compiled.push('  return '.concat(getNamespace(options.namespace), ';'));
         }
         compiled.push('});');
+      } else {
+      	compiled.unshift(getNamespace(options.namespace) + ' = ' + getNamespace(options.namespace) + ' || {};');
       }
 
-      compiled.unshift(getNamespace(options.namespace) + ' = ' + getNamespace(options.namespace) + ' || {};');
+
 
       this.queue(new gulpUtil.File({
         path: fileName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-tojst",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Compile underscore/lodash templates into a single file, using gulp.",
   "author": {
     "name": "Eugene Zlobin",


### PR DESCRIPTION
Hi,
Thank you for your plugin great job!
The only problem I found was when I tried to generate a file containing all my compiled templates and I didn't declared my namespace anywhere else.

So I added a very quick fix to always add the initialisation at the beginning of the file, something like this:

`this["NAMESPACE"] = this["NAMESPACE"] || {};`

I am not sure if it will actually fit all the cases (do we really need that all the time?) and if it should be parametrised. Also I am not really sure about the conventions/parameters of underscore / lodash.

EDIT: I actually added a check and initialisation is only made when amd is set to false.

Please have a look.
Best,
Emanuele
